### PR TITLE
Modified ingress.yaml

### DIFF
--- a/EKS/helm/ingress.yaml
+++ b/EKS/helm/ingress.yaml
@@ -4,10 +4,10 @@ metadata:
   namespace: robot-shop
   name: robot-shop
   annotations:
-    kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
 spec:
+  ingressClassName: alb
   rules:
     - http:
         paths:
@@ -18,3 +18,4 @@ spec:
                 name: web
                 port:
                   number: 8080
+


### PR DESCRIPTION
Deprecated
annotation kubernetes.io/ingress.class is deprecated.

The spec.ingressClassName field is now the standard way to specify the IngressClass for an Ingress resource.