### PR TITLE
Himanshu2

### DIFF
--- a/EKS/04-alb-configuration.md
+++ b/EKS/04-alb-configuration.md
@@ -3,7 +3,7 @@
 Download IAM policy
 
 ```
-curl -O https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.5.4/docs/install/iam_policy.json
+curl -O https://raw.githubusercontent.com/Hii-Himanshu/new_policy/refs/heads/main/new_policy.json
 ```
 
 Create IAM Policy

--- a/EKS/helm/ingress.yaml
+++ b/EKS/helm/ingress.yaml
@@ -4,10 +4,10 @@ metadata:
   namespace: robot-shop
   name: robot-shop
   annotations:
-    kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
 spec:
+  ingressClassName: alb
   rules:
     - http:
         paths:
@@ -18,3 +18,4 @@ spec:
                 name: web
                 port:
                   number: 8080
+


### PR DESCRIPTION
With old policy people are facing error of not assigning the address of load balancer to ingress resource but when I added this {
            "Effect": "Allow",
            "Action": [
                "elasticloadbalancing:DescribeListenerAttributes",
                "elasticloadbalancing:DescribeListeners",
                "elasticloadbalancing:DescribeLoadBalancers",
                "elasticloadbalancing:DescribeTags",
                "elasticloadbalancing:DescribeTargetGroups",
                "elasticloadbalancing:DescribeTargetHealth",
                "elasticloadbalancing:RegisterTargets",
                "elasticloadbalancing:DeregisterTargets"
            ],
            "Resource": "*"
        } now it has resolve the error and now we are getting the address to ing resource and now the address of LoadBalancer is working 